### PR TITLE
Fix version conflicts caused by PR#166

### DIFF
--- a/test/PaymentSystem.Portal.Tests/PaymentSystem.Portal.Tests.csproj
+++ b/test/PaymentSystem.Portal.Tests/PaymentSystem.Portal.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.8" />
         <PackageReference Include="nunit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.AspNetCore.Mvc.Testing from 3.1.5 to 5.0.8. [(PR#166)](https://github.com/klowdo/PaymentSystemCqrs/pull/166).
Hope this fix can help you.

Best regards,
sucrose